### PR TITLE
Deny access to the /farm/settings/modules form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Deny access to the /farm/settings/modules form #23](https://github.com/Regen-Digital/farm_regen_digital/pull/23)
+
 ## 1.3.0 2022-11-02
 
 ### Added

--- a/farm_regen_digital.services.yml
+++ b/farm_regen_digital.services.yml
@@ -1,0 +1,5 @@
+services:
+  farm_regen_digital.route_subscriber:
+    class: Drupal\farm_regen_digital\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\farm_regen_digital\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Add access requirement to data streams.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+
+    // Deny access to farmOS modules form.
+    if ($route = $collection->get('farm_settings.modules_form')) {
+      $route->setRequirement('_access', 'FALSE');
+    }
+  }
+
+}


### PR DESCRIPTION
Farmier currently restricts access to the /farm/settings/modules page in "partner subscription" farmOS instances (Regen Digital instances fall under this umbrella).

This means that farmOS users with the "Account Admin" role in these instances will soon be able to enable additional modules.

If Regen Digital wants to continue restricting access to this page (to keep a more streamlines/curated experience for users by limiting which modules they can turn on), then this restriction will need to be recreated downstream of Farmier code.

This PR adds a simple route subscriber override to deny access to /farm/settings/modules whenever this module is enabled.